### PR TITLE
Case-sensitive password updates to cAppPool

### DIFF
--- a/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
+++ b/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
@@ -47,7 +47,7 @@ function Get-TargetResource
             [xml] $PoolConfig
             $PoolConfig = & $env:SystemRoot\system32\inetsrv\appcmd.exe list apppool $Name /config:*
             if($PoolConfig.add.processModel.userName){
-                $AppPoolPassword = $PoolConfig.add.processModel.password | ConvertTo-SecureString
+                $AppPoolPassword = $PoolConfig.add.processModel.password | ConvertTo-SecureString -AsPlainText -Force
                 $AppPoolCred = new-object -typename System.Management.Automation.PSCredential -argumentlist $PoolConfig.add.processModel.userName,$AppPoolPassword
             }
             else{
@@ -349,7 +349,7 @@ function Set-TargetResource
             #update password if required
             if($identityType -eq "SpecificUser" -and $Password){
                 $clearTextPassword = $Password.GetNetworkCredential().Password
-                if($clearTextPassword -ne $PoolConfig.add.processModel.password){
+                if($clearTextPassword -cne $PoolConfig.add.processModel.password){
                     $UpdateNotRequired = $false
                     & $env:SystemRoot\system32\inetsrv\appcmd.exe set apppool $Name /processModel.password:$clearTextPassword
                 }
@@ -845,7 +845,7 @@ function Test-TargetResource
             #Check password 
             if($identityType -eq "SpecificUser" -and $Password){
                 $clearTextPassword = $Password.GetNetworkCredential().Password
-                if($clearTextPassword -eq $PoolConfig.add.processModel.password){
+                if($clearTextPassword -cne $PoolConfig.add.processModel.password){
                     $DesiredConfigurationMatch = $false
                     Write-Verbose("Password of AppPool $Name does not match the desired state.");
                     break

--- a/cWebAdministration.psd1
+++ b/cWebAdministration.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '2.0.0'
+ModuleVersion = '2.0.1'
 
 # ID used to uniquely identify this module
 GUID = 'b3239f27-d7d3-4ae6-a5d2-d9a1c97d6ae4'


### PR DESCRIPTION
This is a follow-up to #16 .  Fixed old -eq operator in the Test method, and changed them both from -ne to -cne.

Also fixed a bug in the Get method, where a plain text value was being converted to a SecureString without using the -AsPlainText and -Force switches.