### PR TITLE
Updated cAppPool to use single Credential parameter for app-pool identity

### DIFF
--- a/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
+++ b/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
@@ -341,6 +341,10 @@ function Set-TargetResource
                 $UpdateNotRequired = $false
                 & $env:SystemRoot\system32\inetsrv\appcmd.exe set apppool $Name /processModel.identityType:$identityType
             }
+            #Fallback to using username from credential if the userName parameter was not specified
+            if($identityType -eq "SpecificUser" -and $Password -and -not $userName) {
+                $userName = $Password.UserName
+            }
             #update userName if required
             if($identityType -eq "SpecificUser" -and $PoolConfig.add.processModel.userName -ne $userName){
                 $UpdateNotRequired = $false

--- a/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
+++ b/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
@@ -77,7 +77,7 @@ function Get-TargetResource
                                         identityType = $PoolConfig.add.processModel.identityType;
                                         userName = $PoolConfig.add.processModel.userName;
                                         password = $AppPoolCred;
-                                        Credential = $AppPoolCred;
+                                        credential = $AppPoolCred;
                                         loadUserProfile = $PoolConfig.add.processModel.loadUserProfile;
                                         queueLength = $PoolConfig.add.queueLength;
                                         enable32BitAppOnWin64 = $PoolConfig.add.enable32BitAppOnWin64;
@@ -684,6 +684,9 @@ function Test-TargetResource
         [System.Management.Automation.PSCredential]
         $Password,
 
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
         [ValidateSet("true","false")]
         [string]$loadUserProfile = "true",
 
@@ -850,6 +853,16 @@ function Test-TargetResource
                 break
             }
             
+            #Use username from Credential if userName was not given
+            if($Credential -and -not $userName) {
+                $userName = $Credential.UserName
+            }
+
+            #Use Credential as Password if it was omitted
+            if(-not $Password) {
+                $Password = $Credential
+            }
+
             #Check userName 
             if($PoolConfig.add.processModel.userName -ne $userName){
                 $DesiredConfigurationMatch = $false

--- a/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.schema.mof
+++ b/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.schema.mof
@@ -7,13 +7,14 @@ class PSHOrg_cAppPool : OMI_BaseResource
     [write,ValueMap{"v4.0","v2.0",""},Values{"v4.0","v2.0",""}] string managedRuntimeVersion;
     [write,ValueMap{"Integrated","Classic"},Values{"Integrated","Classic"}] string managedPipelineMode;
     [write,ValueMap{"AlwaysRunning","OnDemand"},Values{"AlwaysRunning","OnDemand"}] string startMode;
-    
+
     [write,ValueMap{"ApplicationPoolIdentity","LocalSystem","LocalService","NetworkService","SpecificUser"},
     Values{"ApplicationPoolIdentity","LocalSystem","LocalService","NetworkService","SpecificUser"}]
     string identityType;
-    
+
     [write] string userName;
     [write,EmbeddedInstance("MSFT_Credential")] string Password;
+    [write,EmbeddedInstance("MSFT_Credential")] string Credential;
     [write,ValueMap{"true","false"},Values{"true","false"}] string loadUserProfile;
     [write] string queueLength;
     [write,ValueMap{"true","false"},Values{"true","false"}] string enable32BitAppOnWin64;
@@ -53,6 +54,5 @@ class PSHOrg_cAppPool : OMI_BaseResource
     [write,ValueMap{"true","false"},Values{"true","false"}] string cpuSmpAffinitized;
     [write] string cpuSmpProcessorAffinityMask;
     [write] string cpuSmpProcessorAffinityMask2;
-        
-}; 
 
+};


### PR DESCRIPTION
I started using the cAppPool resource in order to configure my application pools to run as specific users, but I found the API to be a bit redundant. To configure a user you had to specify both the userName and Password parameter. The Password parameter is a PSCredential which has a field for storing usernames, so I figured that I could improve the API a bit.

I implemented a new parameter called Credential, which is a replacement for the separate userName and Password-parameters. When specified, both username and password will be extracted from the PSCredential-instance.

To avoid any backwards compatibility issues I made it so that using the userName or Password parameters take precedence over the Credential-parameter. The Credential is only used when either userName or Password is missing.